### PR TITLE
Bugfix warnings and graph not indexed

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+from src.common.ignore_warnings import ignore_warnings
+
+ignore_warnings()

--- a/src/cmdline.py
+++ b/src/cmdline.py
@@ -1,5 +1,4 @@
 import argparse
-
 import src.logger.log as log
 from src.downloader.download import (
     download_all_workflows_and_actions,

--- a/src/common/ignore_warnings.py
+++ b/src/common/ignore_warnings.py
@@ -1,0 +1,10 @@
+import warnings
+
+
+def ignore_warnings():
+    # Ignore urllib3 warning about OpenSSL version
+    warnings.filterwarnings(
+        "ignore",
+        module="urllib3",
+        message="urllib3 v2.0 only supports OpenSSL 1.1.1+.*",
+    )

--- a/src/indexer/index.py
+++ b/src/indexer/index.py
@@ -20,7 +20,7 @@ Constructor.add_constructor("tag:yaml.org,2002:bool", add_bool)
 
 
 def index_downloaded_workflows_and_actions() -> None:
-    if Config.clean_neo4j:
+    if Config.clean_neo4j or Config.graph.is_graph_empty():
         clean_index()
 
     index_downloaded_actions()

--- a/src/storage/neo4j_graph.py
+++ b/src/storage/neo4j_graph.py
@@ -10,6 +10,10 @@ class GraphDb(object):
     def __init__(self, uri, user, password):
         self.graph = Graph(uri, auth=(user, password))
 
+    def is_graph_empty(self) -> bool:
+        query = "MATCH (n) RETURN COUNT(n) as count"
+        return self.graph.run(query).data()[0]["count"] == 0
+
     def push_object(self, obj: GraphObject):
         self.graph.merge(obj)
 


### PR DESCRIPTION
Add ignore_warnings.py


Fix bug - neo4j graph not indexing when it is empty
but redis history is not empty. This is because
of new container of neo4j but old container of redis.