### PR TITLE
Feature - Add specific repo scan

### DIFF
--- a/src/cmdline.py
+++ b/src/cmdline.py
@@ -3,6 +3,7 @@ import src.logger.log as log
 from src.downloader.download import (
     download_all_workflows_and_actions,
     download_org_workflows_and_actions,
+    download_repo_workflows_and_actions,
 )
 from src.indexer.index import index_downloaded_workflows_and_actions
 from src.reporter.report import generate
@@ -24,6 +25,7 @@ from src.config.config import (
     DOWNLOAD_COMMAND,
     DOWNLOAD_ORG_COMMAND,
     DOWNLOAD_CRAWL_COMMAND,
+    DOWNLOAD_REPO_COMMAND,
     INDEX_COMMAND,
     REPORT_COMMAND,
     QUERIES_PATH_DEFAULT,
@@ -37,6 +39,7 @@ COMMAND_FUNCTIONS = {
     DOWNLOAD_COMMAND: {
         DOWNLOAD_CRAWL_COMMAND: download_all_workflows_and_actions,
         DOWNLOAD_ORG_COMMAND: download_org_workflows_and_actions,
+        DOWNLOAD_REPO_COMMAND: download_repo_workflows_and_actions,
     },
     INDEX_COMMAND: index_downloaded_workflows_and_actions,
     REPORT_COMMAND: generate,
@@ -143,6 +146,12 @@ def raven() -> None:
         parents=[download_parser_options, redis_parser],
     )
 
+    repo_download_parser = download_sub_parser.add_parser(
+        "repo",
+        help="Download specific GitHub repository",
+        parents=[download_parser_options, redis_parser],
+    )
+
     crawl_download_parser.add_argument(
         "--max-stars", type=int, help="Maximum number of stars for a repository"
     )
@@ -160,6 +169,15 @@ def raven() -> None:
         type=str,
         help="Organization name to download the workflows",
     )
+
+    repo_download_parser.add_argument(
+        "--repo-name",
+        required=True,
+        action="append",
+        type=str,
+        help="Repository to download the workflows",
+    )
+
 
     # Index action
     index_parser = subparsers.add_parser(

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -34,6 +34,7 @@ REDIS_ACTIONS_DB = 2
 DOWNLOAD_COMMAND = "download"
 DOWNLOAD_ORG_COMMAND = "org"
 DOWNLOAD_CRAWL_COMMAND = "crawl"
+DOWNLOAD_REPO_COMMAND = "repo"
 INDEX_COMMAND = "index"
 REPORT_COMMAND = "report"
 SEVERITY_LEVELS = {
@@ -62,6 +63,7 @@ def load_downloader_config(args) -> None:
     Config.min_stars = args.get("min_stars", MIN_STARS_DEFAULT)
     Config.max_stars = args.get("max_stars")
     Config.org_name = args.get("org_name")
+    Config.repo_name = args.get("repo_name")
     Config.clean_redis = args.get("clean_redis", REDIS_CLEAN_DEFAULT)
 
     load_redis_config(args)

--- a/src/downloader/download.py
+++ b/src/downloader/download.py
@@ -65,6 +65,24 @@ def download_all_workflows_and_actions() -> None:
         download_workflows_and_actions(repo)
 
 
+def download_repo_workflows_and_actions() -> None:
+    """Download single repository
+
+    We enumerating the .github/workflows directory and download all the workflows.
+    In addition if the repository contains action.yml file, it means it is a composite action,
+    so we download it as well.
+
+    For each such workflow we also scan if it uses additional external actions.
+    If so, we download these as well.
+
+    We are trying to cache the downloads as much as we can to reduce redundant download attempts.
+    """
+    log.debug(f"[+] Scanning single repository")
+
+    for repository in Config.repo_name:
+        download_workflows_and_actions(repository)
+
+
 def download_workflows_and_actions(repo: str) -> None:
     """The flow is the following:
 


### PR DESCRIPTION
Adding scan of individual repository as suggested in [Issue #109](https://github.com/CycodeLabs/raven/issues/109)

The command is used with the following syntax:

`raven download repo --token $GITHUB_TOKEN --repo-name owner/repo-name`

### TODO
* DB cleanup before download, should it clean the entire db (like when you fetch an org) or just that specific entry?