### PR TITLE
chore: bump pyyaml to 6.0.2 to support py3.13 build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ py2neo==2021.2.4
 Pygments==2.18.0
 pytest==8.2.2
 pytz==2024.1
-PyYAML==6.0.1
+PyYAML==6.0.2
 redis==5.0.6
 requests==2.32.3
 six==1.16.0


### PR DESCRIPTION
bump pyyaml to 6.0.2 to support py3.13 build

see 6.0.2 release in here, https://github.com/yaml/pyyaml/releases/tag/6.0.2

relates to https://github.com/Homebrew/homebrew-core/pull/194169